### PR TITLE
Überarbeitung der Autocomplete-Suchvorschläge und die Darstellung der Su...

### DIFF
--- a/core20/core.css
+++ b/core20/core.css
@@ -350,7 +350,7 @@ input.wisy_hinted {
 
 
 /*******************************************************************************
-autocomplete styles
+autocomplete styles v1
 *******************************************************************************/
 
 .ac_results {
@@ -408,6 +408,75 @@ autocomplete styles
 	/*hier koennte man einzelne typen speziell formatieren ...*/
 }
 
+
+/*******************************************************************************
+autocomplete styles v2
+*******************************************************************************/
+
+/* jQuery UI autocompleter */
+.ui-helper-hidden-accessible { display: none; }
+
+.ac_results_v2 { max-height: 400px; overflow-y: auto; }
+.ac_results_v2 li { padding: 2px 4px; }
+.ac_results_v2 li > a { display: block; padding: 2px 0; cursor: default; }
+.ac_results_v2 .ui-state-focus { background-color: #444; color: #fff; }
+
+.ac_results_v2 .tag_name { margin-right: 1em; }
+.ac_results_v2 .tag_count { font-size: 10px; color: #666; margin-right: 0.5em;  }
+.ac_results_v2 .tag_type { font-size: 10px; color: #444; }
+
+.ac_results_v2 .ui-state-focus .tag_name { color: #fff!important; }
+.ac_results_v2 .ui-state-focus .tag_count { color: #aaa!important; }
+.ac_results_v2 .ui-state-focus .tag_type { color: #ddd!important; }
+
+.ac_results_v2 .ac_more a { color: #000; font-weight: bold; }
+.ac_results_v2 .ui-state-focus .ac_more a { color: #fff; }
+
+.ac_results_v2 .ac_headline .tag_name,
+.ac_results_v2 .ac_more .tag_name { width: 100%; }
+
+/* Vorschläge im Hauptfenster */
+.wisy_tagtable { border-spacing: 1px; }
+.wisy_tagtable th { 
+	color: #000;
+	background-color: #E2E2E2;
+	padding: 3px 5px 3px 5px;
+	text-align: left;
+	border-bottom: 1px solid #000;
+}
+.wisy_tagtable th.titel { width: 52%; }
+.wisy_tagtable .tag_count { float: right; }
+.wisy_tagtable th.art { width: 10%; }
+.wisy_tagtable th.gruppe { width: 24%; }
+.wisy_tagtable th.info { width: 14%; }
+.wisy_tagtable td { vertical-align: bottom; padding: 2px 4px; }
+.wisy_tagtable .ac_indent .td.tag_name { padding-left: 20px; }
+.wisy_tagtable .ac_indent .td.tag_name:before { content: '\2192'; position: absolute; left: 5px; }
+
+/* Allgemeine Auszeichnungen */
+.ac_abschluss .tag_name a, tr.ac_abschluss { font-weight: bold; }
+.ac_foerderung .tag_name a, tr.ac_foerderung { font-weight: bold; color: red; }
+.ac_suggestion { color: #444; }
+.ui-state-focus .ac_suggestion { color: #ddd; }
+
+.ac_anbieter .tag_type { color: green; }
+.ac_foerderung .tag_type { font-weight: bold; }
+.ac_thema .tag_type { font-weight: bold; }
+
+.ac_normal .tag_name, .ac_normal .tag_name a,
+.ac_abschluss .tag_name, .ac_abschluss .tag_name a  { color: #000; }
+.ac_anbieter .tag_name, .ac_anbieter .tag_name a { color: green; }
+.ac_qualitaetszertifikat .tag_name { color: #3E7AB8; }
+
+.ac_ort .tag_type,
+.ac_zielgruppe .tag_type,
+.ac_qualitaetszertifikat .tag_type,
+.ac_unterrichtsart .tag_type { color: #3E7AB8; }
+
+.tag_count, .tag_groups { color: #000; font-weight: normal!important; font-style: normal!important; }
+.tag_info a { color: #666; font-weight: bold; }
+.ac_anbieter .tag_info a { font-weight: normal; }
+.tag_info a:hover { color: #3e7ab8; }
 
 
 /*******************************************************************************

--- a/core20/wisy-autosuggest-renderer-class.inc.php
+++ b/core20/wisy-autosuggest-renderer-class.inc.php
@@ -74,8 +74,26 @@ class WISY_AUTOSUGGEST_RENDERER_CLASS
 			default:
 				// return as simple text, one tag per line, used by the site's AutoSuggest
 				$tags = $tagsuggestor->suggestTags($querystring, array('max'=>10));
+				
+				if($this->framework->iniRead('search.suggest.v2') == 1)
+				{
+				
+					// add Headline and MoreLink at the beginning
+					array_unshift($tags, array(
+						'tag' => $querystring,
+						'tag_descr' => 'Suchvorschl&auml;ge:',
+						'tag_type'	=> 0,
+						'tag_help'	=> -1 // indicates "headline"
+					),
+					array(
+						'tag'	=>	$querystring,
+						'tag_descr' => sizeof($tags)? 'Alle Vorschl&auml;ge im Hauptfenster anzeigen ...' : 'Keine Treffer',
+						'tag_type'	=> 0,
+						'tag_help'	=> 1 // indicates "more"
+					));	
+				}
 
-				// addMoreLink
+				// addMoreLink at the end
 				$tags[] = array(
 					'tag'	=>	$querystring,
 					'tag_descr' => sizeof($tags)? 'Alle Vorschl&auml;ge im Hauptfenster anzeigen ...' : 'Keine Treffer',

--- a/core20/wisy-framework-class.inc.php
+++ b/core20/wisy-framework-class.inc.php
@@ -791,8 +791,17 @@ class WISY_FRAMEWORK_CLASS
 	{
 		// return all JavaScript files as an array
 		$ret = array();
-		$ret[] = 'jquery-1.4.3.min.js';
-		$ret[] = 'jquery.autocomplete.min.js';
+		
+		if($this->iniRead('search.suggest.v2') == 1)
+		{
+			$ret[] = '/admin/lib/jquery/js/jquery-1.10.2.min.js';
+			$ret[] = '/admin/lib/jquery/js/jquery-ui-1.10.4.custom.min.js';
+		}
+		else
+		{
+			$ret[] = 'jquery-1.4.3.min.js';
+			$ret[] = 'jquery.autocomplete.min.js';
+		}
 		$ret[] = 'jquery.wisy.js' . $this->includeVersion;
 		
 		return $ret;


### PR DESCRIPTION
...chvorschläge im Hauptfenster.

Die überarbeitete Version wird verwendet wenn in den Einstellungen "search.suggest.v2 = 1" gesetzt ist. Ist diese Einstellung nicht gesetzt sollte der neue Code keinerlei Auswirkungen haben.

Umstellung der zu Grunde liegenden Funktion auf jQuery UI autocomplete, da die bisher verwendete Funktion nicht mehr weiterentwickelt und der Umstieg auf jQuery UI empfohlen wird. Damit einhergehend die Einbindung der aktuell im Admin-Bereich verwendeten jQuery und jQuery UI Funktionen.

Die Darstellung im Ajax-Fenster ist farblich überarbeitet (neue Styles in core.css) und zeigt oberhalb der Vorschläge eine Überschrift ("Suchvorschläge:").
Die Darstellung im Hauptfenster ist jetzt tabellarisch und um Oberbegriffe ("tag_groups") und ggf. den Link zum Anbieter ("tag_anbieter_id") erweitert worden. Dabei wurden auch einige Bezeichnungen geändert ("Qualitätszertifikat" -> "Quailtätsmerkmal" usw.)