### PR TITLE
Darstellung der Suchvorschläge leicht überarbeitet, Suchstring hervorgehoben

### DIFF
--- a/core20/core.css
+++ b/core20/core.css
@@ -444,12 +444,12 @@ autocomplete styles v2
 	text-align: left;
 	border-bottom: 1px solid #000;
 }
-.wisy_tagtable th.titel { width: 52%; }
+.wisy_tagtable th.titel { width: 60%; }
 .wisy_tagtable .tag_count { float: right; }
 .wisy_tagtable th.art { width: 10%; }
-.wisy_tagtable th.gruppe { width: 24%; }
-.wisy_tagtable th.info { width: 14%; }
-.wisy_tagtable td { vertical-align: bottom; padding: 2px 4px; }
+.wisy_tagtable th.gruppe { width: 15%; }
+.wisy_tagtable th.info { width: 15%; }
+.wisy_tagtable td { vertical-align: top; padding: 2px 4px; }
 .wisy_tagtable .ac_indent .td.tag_name { padding-left: 20px; }
 .wisy_tagtable .ac_indent .td.tag_name:before { content: '\2192'; position: absolute; left: 5px; }
 
@@ -477,6 +477,12 @@ autocomplete styles v2
 .tag_info a { color: #666; font-weight: bold; }
 .ac_anbieter .tag_info a { font-weight: normal; }
 .tag_info a:hover { color: #3e7ab8; }
+
+/* Hervorhebung des Suchstrings */
+.tag_name em {
+	border-bottom: 1px solid #3E7AB8;
+	font-style: inherit;
+}
 
 
 /*******************************************************************************

--- a/core20/jquery.wisy.js
+++ b/core20/jquery.wisy.js
@@ -312,7 +312,7 @@ function initAutocomplete()
 
 if (jQuery.ui)
 {
-	function formatItem_v2(row)
+	function formatItem_v2(row, request_term)
 	{
 		var tag_name  = row[0];
 		var tag_descr = row[1];
@@ -393,6 +393,10 @@ if (jQuery.ui)
 				row_info = ' <a class="wisy_help" href="" onclick="return clickAutocompleteHelp(' + tag_help + ', &#39;' + encodeURIComponent(tag_name) + '&#39;)">&nbsp;i&nbsp;</a>';
 			}
 		}
+		
+		// highlight search string
+		var regex = new RegExp("(?![^&;]+;)(?!<[^<>]*)(" + request_term.replace(/([\^\$\(\)\[\]\{\}\*\.\+\?\|\\])/gi, "\\$1") + ")(?![^<>]*>)(?![^&;]+;)", "gi");
+		tag_name = tag_name.replace(regex, "<em>$1</em>");
 	
 		return '<span class="row '+row_class+'">' + 
 					'<span class="tag_name">' + row_prefix + tag_name + row_postfix + '</span>' + 
@@ -405,7 +409,8 @@ if (jQuery.ui)
 	function ac_sourcecallback(request, response_callback)
 	{	
 		// calculate the new source url
-		var url = "autosuggest?q=" + encodeURIComponent(extractLast(request.term)) + "&limit=512&timestamp=" + new Date().getTime();
+		var request_term = extractLast(request.term);
+		var url = "autosuggest?q=" + encodeURIComponent(request_term) + "&limit=512&timestamp=" + new Date().getTime();
 	
 		// ask the server for suggestions
 		$.get(url, function(data)
@@ -420,7 +425,7 @@ if (jQuery.ui)
 				if(data[i] != "")
 				{
 					var row = data[i].split("|");
-					response_data.push({ label: formatItem_v2(row), value: row[0] });
+					response_data.push({ label: formatItem_v2(row, request_term), value: row[0] });
 				}
 			}
 			response_callback(response_data);

--- a/core20/wisy-search-renderer-class.inc.php
+++ b/core20/wisy-search-renderer-class.inc.php
@@ -406,7 +406,7 @@ class WISY_SEARCH_RENDERER_CLASS
 			   '</span>';
 	}
 	
-	function formatItem_v2($tag_name, $tag_descr, $tag_type, $tag_help, $tag_freq, $tag_anbieter_id=false, $tag_groups='', $tr_class='')
+	function formatItem_v2($tag_name, $tag_descr, $tag_type, $tag_help, $tag_freq, $tag_anbieter_id=false, $tag_groups='', $tr_class='', $queryString='')
 	{
 		/* see also (***) in the JavaScript part*/
 		$row_class   = 'ac_normal';
@@ -462,7 +462,7 @@ class WISY_SEARCH_RENDERER_CLASS
 			$row_prefix = ''; //13.05.2014 was: 'Suche nach '
 		}
 	
-		if( $tag_groups ) $row_groups = implode(', ', $tag_groups);
+		if( $tag_groups ) $row_groups = implode('<br />', $tag_groups);
 	
 		if( $tag_help )
 		{
@@ -472,9 +472,18 @@ class WISY_SEARCH_RENDERER_CLASS
 		}
 	
 		$row_class = $row_class . ' ' . $tr_class;
+		
+		// highlight search string
+		$tag_name = isohtmlspecialchars($tag_name);
+		if($queryString != '') {
+			//$tag_name_highlighted = str_ireplace($queryString, "<strong>$queryString</strong>", $tag_name);
+			$tag_name_highlighted = preg_replace("/".preg_quote($queryString, "/")."/i", "<em>$0</em>", $tag_name);
+		} else {
+			$tag_name_highlighted = $tag_name;
+		}
 	
 		return '<tr class="' .$row_class. '">' .
-					'<td class="tag_name">'. $row_prefix .'<a href="' . $this->framework->getUrl('search', array('q'=>$tag_name)) . '">' . isohtmlspecialchars($tag_name) . '</a>'. $row_postfix .'<span class="tag_count">'. $row_count .'</span></td>' . 
+					'<td class="tag_name">'. $row_prefix .'<a href="' . $this->framework->getUrl('search', array('q'=>$tag_name)) . '">' . $tag_name_highlighted . '</a>'. $row_postfix .'<span class="tag_count">'. $row_count .'</span></td>' . 
 					'<td class="tag_type">'. $row_type .'</td>' .
 					'<td class="tag_groups">'. $row_groups .'</td>' . 
 					'<td class="tag_info">'. $row_info . '</td>' .
@@ -504,7 +513,7 @@ class WISY_SEARCH_RENDERER_CLASS
 				for( $i = 0; $i < sizeof($suggestions); $i++ )
 				{
 					$tr_class = ($i%2) ? 'ac_even' : 'ac_odd';
-					echo $this->formatItem_v2($suggestions[$i]['tag'], $suggestions[$i]['tag_descr'], $suggestions[$i]['tag_type'], intval($suggestions[$i]['tag_help']), intval($suggestions[$i]['tag_freq']), $suggestions[$i]['tag_anbieter_id'], $suggestions[$i]['tag_groups'], $tr_class);
+					echo $this->formatItem_v2($suggestions[$i]['tag'], $suggestions[$i]['tag_descr'], $suggestions[$i]['tag_type'], intval($suggestions[$i]['tag_help']), intval($suggestions[$i]['tag_freq']), $suggestions[$i]['tag_anbieter_id'], $suggestions[$i]['tag_groups'], $tr_class, $queryString);
 				}
 				echo '	</tbody>';
 				echo '</table>';


### PR DESCRIPTION
Oberbegriffe im Hauptfenster nicht kommasepariert nebeneinander sondern umbrochen (<br />) untereinander anzeigen. Spaltenbreiten der Tabelle im CSS entsprechend anpassen.

Suchstring im Ajax-Feld und im Hauptfenster mit <em> auszeichnen. Per CSS unterstrichen hervorheben.